### PR TITLE
Fix month indexing in date filter keys

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,7 @@ const RESULTS_PER_PAGE = 5;
  * @returns A Date object for sorting. Unsortable strings result in an old date.
  */
 const getSortableDate = (dateString: string): Date => {
-    // Standard YYYY-MM format (month is 0-indexed in key)
+    // Standard YYYY-MM format (month is 1-indexed)
     const yyyyMmMatch = dateString.match(/^(\d{4})-(\d{2})$/);
     if (yyyyMmMatch) {
         // new Date(year, monthIndex, day)
@@ -236,7 +236,7 @@ const App: React.FC = () => {
         if (trend.datePublished) {
             const date = trend.datePublished;
             const year = date.getUTCFullYear();
-            const month = date.getUTCMonth(); // 0-indexed
+            const month = date.getUTCMonth() + 1; // 1-12
             const key = `${year}-${String(month).padStart(2, '0')}`;
             
             if (!dateOptionsMap.has(key)) {
@@ -283,7 +283,7 @@ const App: React.FC = () => {
             if (trend.datePublished) {
                 const date = trend.datePublished;
                 const year = date.getUTCFullYear();
-                const month = date.getUTCMonth();
+                const month = date.getUTCMonth() + 1;
                 const trendKey = `${year}-${String(month).padStart(2, '0')}`;
                 dateMatch = trendKey === filterValue;
             } else {


### PR DESCRIPTION
## Summary
- correct month key generation so date filters use human-readable 1-based months
- ensure filtering and sorting compare against the same normalized date keys

## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails: JSX element implicitly has type 'any'; missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6890d43197948320b45e2ae15d1875f2