### PR TITLE
Remove browse database heading from results

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,7 +15,6 @@ const App: React.FC = () => {
     // Client-side Filter State
     const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
     const [selectedCompanies, setSelectedCompanies] = useState<string[]>([]);
-    const [selectedDates, setSelectedDates] = useState<string[]>([]);
     const [searchTerm, setSearchTerm] = useState('');
 
     // Modal State
@@ -41,16 +40,13 @@ const App: React.FC = () => {
     const filterOptions = useMemo<FilterOptions>(() => {
         const topics = new Set<string>();
         const companies = new Set<string>();
-        const dates = new Set<string>();
         allData.forEach(item => {
             if (item.Topic) topics.add(item.Topic);
             if (item.Company) companies.add(item.Company);
-            if (item.Date) dates.add(item.Date);
         });
         return {
             topics: Array.from(topics).sort(),
             companies: Array.from(companies).sort(),
-            dates: Array.from(dates).sort((a, b) => new Date(b).getTime() - new Date(a).getTime()),
         };
     }, [allData]);
 
@@ -58,8 +54,7 @@ const App: React.FC = () => {
         return allData.filter(item => {
             const topicMatch = selectedTopics.length === 0 || selectedTopics.includes(item.Topic);
             const companyMatch = selectedCompanies.length === 0 || selectedCompanies.includes(item.Company);
-            const dateMatch = selectedDates.length === 0 || selectedDates.includes(item.Date);
-            
+
             const searchLower = searchTerm.toLowerCase();
             const termMatch = searchTerm === '' ||
                 item.stat.toLowerCase().includes(searchLower) ||
@@ -68,9 +63,9 @@ const App: React.FC = () => {
                 item.Topic.toLowerCase().includes(searchLower) ||
                 item.Technology.toLowerCase().includes(searchLower);
 
-            return topicMatch && companyMatch && dateMatch && termMatch;
+            return topicMatch && companyMatch && termMatch;
         });
-    }, [allData, selectedTopics, selectedCompanies, selectedDates, searchTerm]);
+    }, [allData, selectedTopics, selectedCompanies, searchTerm]);
 
     const handleStatSelect = (stat: TrendData) => {
         setSelectedStat(stat);
@@ -83,11 +78,9 @@ const App: React.FC = () => {
     // Filter handlers
     const handleTopicToggle = (topic: string) => setSelectedTopics(prev => prev.includes(topic) ? prev.filter(t => t !== topic) : [...prev, topic]);
     const handleCompanyToggle = (company: string) => setSelectedCompanies(prev => prev.includes(company) ? prev.filter(c => c !== company) : [...prev, company]);
-    const handleDateToggle = (date: string) => setSelectedDates(prev => prev.includes(date) ? prev.filter(d => d !== date) : [...prev, date]);
     const handleResetFilters = () => {
         setSelectedTopics([]);
         setSelectedCompanies([]);
-        setSelectedDates([]);
         setSearchTerm('');
     };
 
@@ -118,8 +111,6 @@ const App: React.FC = () => {
                     onTopicToggle={handleTopicToggle}
                     selectedCompanies={selectedCompanies}
                     onCompanyToggle={handleCompanyToggle}
-                    selectedDates={selectedDates}
-                    onDateToggle={handleDateToggle}
                     onResetFilters={handleResetFilters}
                 />
                 <div className="flex-1 min-w-0">

--- a/App.tsx
+++ b/App.tsx
@@ -134,9 +134,6 @@ const App: React.FC = () => {
                                 className="w-full pl-12 pr-4 py-3 bg-slate-800 border border-slate-700 rounded-lg text-slate-200 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 outline-none"
                             />
                         </div>
-                        <h3 className="text-xl font-semibold text-slate-200 mb-4">
-                            Browse Database <span className="text-base font-normal text-slate-400">({filteredData.length} stats found)</span>
-                        </h3>
                         {filteredData.length > 0 ? (
                             <StatsTable stats={filteredData} onStatSelect={handleStatSelect} />
                         ) : (

--- a/components/FilterSidebar.tsx
+++ b/components/FilterSidebar.tsx
@@ -1,9 +1,9 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { FilterOptions } from '../types';
-import { 
-    FilterIcon, RefreshCwIcon, TagIcon, BuildingIcon, 
-    CalendarIcon, SearchIcon, ChevronDownIcon, ChevronUpIcon, XIcon 
+import {
+    FilterIcon, RefreshCwIcon, TagIcon, BuildingIcon,
+    SearchIcon, ChevronDownIcon, ChevronUpIcon, XIcon
 } from './Icons';
 
 interface FilterSidebarProps {
@@ -12,8 +12,6 @@ interface FilterSidebarProps {
     onTopicToggle: (value: string) => void;
     selectedCompanies: string[];
     onCompanyToggle: (value: string) => void;
-    selectedDates: string[];
-    onDateToggle: (value: string) => void;
     onResetFilters: () => void;
 }
 
@@ -113,8 +111,6 @@ export const FilterSidebar: React.FC<FilterSidebarProps> = ({
     onTopicToggle,
     selectedCompanies,
     onCompanyToggle,
-    selectedDates,
-    onDateToggle,
     onResetFilters
 }) => {
     

--- a/components/TrendCard.tsx
+++ b/components/TrendCard.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { TrendData } from '../types';
-import { BuildingIcon, CalendarIcon, LinkIcon, TagIcon, CpuIcon, InfoIcon } from './Icons';
+import { BuildingIcon, CalendarIcon, LinkIcon, TagIcon, CpuIcon } from './Icons';
 
 interface TrendCardProps {
-    trend: TrendData & { reason?: string };
+    trend: TrendData;
 }
 
 const CardInfoRow: React.FC<{ icon: React.ReactNode; label: string; value?: string }> = ({ icon, label, value }) => {
@@ -30,19 +30,6 @@ export const TrendCard: React.FC<TrendCardProps> = ({ trend }) => {
                 <CardInfoRow icon={<CpuIcon />} label="Technology" value={trend.Technology} />
                 <CardInfoRow icon={<CalendarIcon />} label="Date" value={trend.Date} />
             </div>
-
-            {trend.reason && (
-                <div className="mt-4 pt-3 border-t border-slate-700 bg-slate-900/50 p-3 rounded-md">
-                    <div className="flex items-start text-sm">
-                        <span className="text-cyan-400 w-5 h-5 flex-shrink-0 mr-2 mt-0.5"><InfoIcon /></span>
-                        <div>
-                           <p className="font-semibold text-slate-300">AI's Reason for Selection:</p>
-                           <p className="text-slate-400 italic">"{trend.reason}"</p>
-                        </div>
-                    </div>
-                </div>
-            )}
-
             {trend.Source && (
                 <div className="mt-4 pt-3 border-t border-slate-700">
                     <a

--- a/types.ts
+++ b/types.ts
@@ -11,5 +11,4 @@ export interface TrendData {
 export interface FilterOptions {
     topics: string[];
     companies: string[];
-    dates: string[];
 }


### PR DESCRIPTION
## Summary
- remove the "Browse Database" heading so the results list no longer surfaces the count banner

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e24ba2ee048320876495ea3a9eb73d